### PR TITLE
Add leave option and online user count

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { ReactNode } from 'react'
+import OnlineUsers from '@/components/OnlineUsers'
 
 export const metadata = {
   title: 'Game Service',
@@ -10,8 +11,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen">
-        <header className="container py-3">
+        <header className="container py-3 flex items-center justify-between">
           <h1 className="text-xl font-bold">Game Service</h1>
+          {/* show number of users currently online */}
+          <OnlineUsers />
         </header>
         <main>{children}</main>
       </body>

--- a/src/components/OnlineUsers.tsx
+++ b/src/components/OnlineUsers.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export default function OnlineUsers() {
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    const client = supabase()
+    let channel: any
+    ;(async () => {
+      const { data } = await client.auth.getUser()
+      channel = client.channel('online-users', {
+        config: { presence: { key: data.user?.id || Math.random().toString() } }
+      })
+      channel.on('presence', { event: 'sync' }, () => {
+        const state = channel.presenceState()
+        setCount(Object.keys(state).length)
+      })
+      await channel.subscribe()
+      channel.track({})
+    })()
+    return () => { if (channel) client.removeChannel(channel) }
+  }, [])
+  return <span className="text-sm opacity-70">Online: {count}</span>
+}

--- a/src/components/RoomShell.tsx
+++ b/src/components/RoomShell.tsx
@@ -63,7 +63,21 @@ export default function RoomShell({ roomId, role }: { roomId: string; role: 'X'|
 
   return (
     <div className="container py-4">
-      <div className="mb-4 text-sm opacity-70">Room: {roomId} · You are {role}</div>
+      <div className="mb-4 flex items-center justify-between text-sm opacity-70">
+        <div>Room: {roomId} · You are {role}</div>
+        <button
+          className="underline"
+          onClick={() => {
+            if (leaveRef.current) {
+              void leaveRef.current()
+              leaveRef.current = null
+            }
+            window.location.href = '/'
+          }}
+        >
+          Leave match
+        </button>
+      </div>
       <TicTacToeBoard board={board} canMove={canMove} onMove={makeMove} />
     </div>
   )


### PR DESCRIPTION
## Summary
- Add global online user indicator using Supabase presence
- Provide Leave match button to exit game and return home

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899a4c501a08330a589668a2629e7d9