### PR TITLE
Show user email in header and fix room removal

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { ReactNode } from 'react'
 import OnlineUsers from '@/components/OnlineUsers'
+import UserEmail from '@/components/UserEmail'
 
 export const metadata = {
   title: 'Game Service',
@@ -13,8 +14,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="min-h-screen">
         <header className="container py-3 flex items-center justify-between">
           <h1 className="text-xl font-bold">Game Service</h1>
-          {/* show number of users currently online */}
-          <OnlineUsers />
+          <div className="flex items-center gap-4">
+            {/* show user email and number of users online */}
+            <UserEmail />
+            <OnlineUsers />
+          </div>
         </header>
         <main>{children}</main>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,7 +120,17 @@ export default function Home() {
                           const ok = confirm('Delete this room?')
                           if (!ok) return
                           const client = supabase()
-                          await client.from('matches').delete().eq('id', r.id)
+                          // attempt to remove room; if deletion fails, mark finished
+                          const { error } = await client
+                            .from('matches')
+                            .delete()
+                            .eq('id', r.id)
+                          if (error) {
+                            await client
+                              .from('matches')
+                              .update({ status: 'finished' })
+                              .eq('id', r.id)
+                          }
                           setRooms((prev) => prev.filter((room) => room.id !== r.id))
                         }}
                       >

--- a/src/components/UserEmail.tsx
+++ b/src/components/UserEmail.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export default function UserEmail() {
+  const [email, setEmail] = useState<string | null>(null)
+
+  useEffect(() => {
+    const client = supabase()
+    client.auth.getUser().then(({ data }) => setEmail(data.user?.email ?? null))
+  }, [])
+
+  if (!email) return null
+  return <span className="text-sm opacity-70">{email}</span>
+}


### PR DESCRIPTION
## Summary
- display signed-in user's email in the header
- ensure deleting a room updates backend and removes room from list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_6899b129c1308330ad53a1b5053dff27