### PR TITLE
feat: allow deleting room

### DIFF
--- a/src/components/RoomShell.tsx
+++ b/src/components/RoomShell.tsx
@@ -65,18 +65,35 @@ export default function RoomShell({ roomId, role }: { roomId: string; role: 'X'|
     <div className="container py-4">
       <div className="mb-4 flex items-center justify-between text-sm opacity-70">
         <div>Room: {roomId} · You are {role}</div>
-        <button
-          className="underline"
-          onClick={() => {
-            if (leaveRef.current) {
-              void leaveRef.current()
-              leaveRef.current = null
-            }
-            window.location.href = '/'
-          }}
-        >
-          Leave match
-        </button>
+        <div className="flex gap-4">
+          <button
+            className="underline"
+            onClick={() => {
+              if (leaveRef.current) {
+                void leaveRef.current()
+                leaveRef.current = null
+              }
+              window.location.href = '/'
+            }}
+          >
+            Leave match
+          </button>
+          <button
+            className="underline"
+            onClick={async () => {
+              if (!confirm('Delete this room?')) return
+              const client = supabase()
+              await client.from('matches').delete().eq('id', roomId)
+              if (leaveRef.current) {
+                await leaveRef.current()
+                leaveRef.current = null
+              }
+              window.location.href = '/'
+            }}
+          >
+            Delete room
+          </button>
+        </div>
       </div>
       <TicTacToeBoard board={board} canMove={canMove} onMove={makeMove} />
     </div>

--- a/supabase.sql
+++ b/supabase.sql
@@ -87,6 +87,11 @@ for update using (
   status = 'waiting' or auth.uid() in (player_x, player_o, created_by)
 );
 
+create policy "matches: delete if participant or waiting" on public.matches
+for delete using (
+  status = 'waiting' or auth.uid() in (player_x, player_o, created_by)
+);
+
 create policy "moves: read all" on public.moves
 for select using (true);
 


### PR DESCRIPTION
## Summary
- allow players to remove a room from inside the room
- permit match deletion for participants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899b31c3f80833098ddd60c3a65d80e