### PR TITLE
feat: add logout button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import type { ReactNode } from 'react'
 import OnlineUsers from '@/components/OnlineUsers'
 import UserEmail from '@/components/UserEmail'
+import LogoutButton from '@/components/LogoutButton'
 
 export const metadata = {
   title: 'Game Service',
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <div className="flex items-center gap-4">
             {/* show user email and number of users online */}
             <UserEmail />
+            <LogoutButton />
             <OnlineUsers />
           </div>
         </header>

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export default function LogoutButton() {
+  const [signedIn, setSignedIn] = useState(false)
+
+  useEffect(() => {
+    supabase()
+      .auth.getUser()
+      .then(({ data }) => setSignedIn(!!data.user))
+  }, [])
+
+  if (!signedIn) return null
+
+  return (
+    <button
+      className="px-2 py-1 rounded-xl border text-sm"
+      onClick={async () => {
+        await supabase().auth.signOut()
+        window.location.href = '/'
+      }}
+    >
+      Logout
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a client-side logout button that signs out via Supabase and redirects home
- show the logout button in the site header next to the user email and online count

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899b6487e6c8330987257912c51790e