### PR TITLE
Enable chess gameplay option

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { games, gameBySlug } from '@/games'
 import { supabase } from '@/lib/supabase'
 import { useEffect, useState } from 'react'
+import { initialSnapshot as chessInitialSnapshot } from '@/games/chess/engine'
 
 export default function Home() {
   const [user, setUser] = useState<any>(null)
@@ -83,6 +84,9 @@ export default function Home() {
                       game_slug: g.slug,
                       created_by: profile.user!.id,
                       player_x: profile.user!.id,
+                      ...(g.slug === 'chess'
+                        ? { snapshot: chessInitialSnapshot(), current_turn: 'w' }
+                        : {}),
                     })
                     .select('id')
                     .single()

--- a/src/app/play/[game]/[roomId]/page.tsx
+++ b/src/app/play/[game]/[roomId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import RoomShell from '@/components/RoomShell'
+import ChessRoom from '@/components/ChessRoom'
 import { supabase } from '@/lib/supabase'
 import { useParams } from 'next/navigation'
 
@@ -33,5 +34,9 @@ export default function RoomPage() {
   }, [params.roomId])
 
   if (loading || !role) return <div className="container py-6">Joining room…</div>
-  return <RoomShell roomId={params.roomId} role={role} />
+  return params.game === 'chess' ? (
+    <ChessRoom roomId={params.roomId} role={role === 'X' ? 'w' : 'b'} />
+  ) : (
+    <RoomShell roomId={params.roomId} role={role} />
+  )
 }

--- a/src/components/ChessRoom.tsx
+++ b/src/components/ChessRoom.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { joinRoom, type GameEvent } from '@/lib/realtime'
+import {
+  initialSnapshot,
+  applyMove,
+  winner,
+  nextTurn,
+  type Snapshot,
+  type Move,
+} from '@/games/chess/engine'
+import { ChessBoard } from '@/games/chess/ui'
+import { supabase } from '@/lib/supabase'
+
+export default function ChessRoom({ roomId, role }: { roomId: string; role: 'w' | 'b' }) {
+  const [snapshot, setSnapshot] = useState<Snapshot>(initialSnapshot())
+  const [turn, setTurn] = useState<'w' | 'b'>('w')
+  const [result, setResult] = useState<'w' | 'b' | 'draw' | null>(null)
+  const sendRef = useRef<null | ((e: GameEvent) => Promise<unknown>)>(null)
+  const leaveRef = useRef<null | (() => Promise<unknown>)>(null)
+  const [players, setPlayers] = useState<{ w: string | null; b: string | null }>({
+    w: null,
+    b: null,
+  })
+
+  useEffect(() => {
+    if (!result) return
+    const t = setTimeout(() => {
+      if (leaveRef.current) {
+        void leaveRef.current()
+        leaveRef.current = null
+      }
+      window.location.href = '/'
+    }, 5000)
+    return () => clearTimeout(t)
+  }, [result])
+
+  useEffect(() => {
+    ;(async () => {
+      const { send, leave } = await joinRoom(roomId, (e: GameEvent) => {
+        if (e.type === 'state' && 'currentTurn' in e && (e.currentTurn === 'w' || e.currentTurn === 'b')) {
+          setSnapshot(e.snapshot)
+          setTurn(e.currentTurn)
+          setResult(e.winner ?? null)
+        }
+        if (e.type === 'move' && 'from' in e && 'to' in e) {
+          setSnapshot((s) => {
+            const ns = applyMove(s, { from: e.from, to: e.to, promotion: (e as any).promotion })
+            const w = winner(ns)
+            if (w) setResult(w)
+            else setTurn(nextTurn(ns))
+            return ns
+          })
+        }
+      })
+      sendRef.current = send
+      leaveRef.current = leave
+    })()
+    return () => {
+      if (leaveRef.current) void leaveRef.current()
+    }
+  }, [roomId])
+
+  useEffect(() => {
+    const client = supabase()
+    client
+      .from('matches')
+      .select('player_x, player_o')
+      .eq('id', roomId)
+      .single()
+      .then(({ data }) => setPlayers({ w: data?.player_x ?? null, b: data?.player_o ?? null }))
+  }, [roomId])
+
+  const canMove = result == null && turn === role
+
+  const makeMove = async (move: Move) => {
+    if (!canMove) return
+    const ns = applyMove(snapshot, move)
+    if (ns === snapshot) return
+    const w = winner(ns)
+
+    if (sendRef.current)
+      void sendRef.current({ type: 'move', from: move.from, to: move.to, promotion: move.promotion })
+
+    setSnapshot(ns)
+    setResult(w)
+    setTurn(nextTurn(ns))
+
+    const client = supabase()
+    await client
+      .from('matches')
+      .update({ snapshot: ns, current_turn: nextTurn(ns), winner: w ?? null })
+      .eq('id', roomId)
+
+    if (w && players.w && players.b && w !== 'draw') {
+      const winnerId = w === 'w' ? players.w : players.b
+      const loserId = w === 'w' ? players.b : players.w
+      const { data: winP } = await client.from('profiles').select('wins').eq('id', winnerId).single()
+      await client
+        .from('profiles')
+        .update({ wins: (winP?.wins ?? 0) + 1 })
+        .eq('id', winnerId)
+      const { data: loseP } = await client.from('profiles').select('losses').eq('id', loserId).single()
+      await client
+        .from('profiles')
+        .update({ losses: (loseP?.losses ?? 0) + 1 })
+        .eq('id', loserId)
+      await client.from('matches').delete().eq('id', roomId)
+    }
+  }
+
+  return (
+    <div className="container py-4">
+      <div className="mb-4 flex items-center justify-between text-sm opacity-70">
+        <div>
+          Room: {roomId} · You are {role === 'w' ? 'White' : 'Black'}
+        </div>
+        <div className="flex gap-4">
+          <button
+            className="underline"
+            onClick={() => {
+              if (leaveRef.current) {
+                void leaveRef.current()
+                leaveRef.current = null
+              }
+              window.location.href = '/'
+            }}
+          >
+            Leave match
+          </button>
+          <button
+            className="underline"
+            onClick={async () => {
+              if (!confirm('Delete this room?')) return
+              const client = supabase()
+              await client.from('matches').delete().eq('id', roomId)
+              if (leaveRef.current) {
+                await leaveRef.current()
+                leaveRef.current = null
+              }
+              window.location.href = '/'
+            }}
+          >
+            Delete room
+          </button>
+        </div>
+      </div>
+      <ChessBoard snapshot={snapshot} canMove={canMove} onMove={makeMove} />
+      {result && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/60">
+          <div className="rounded-2xl bg-white p-6 text-xl text-center">
+            {result === 'draw' ? 'Draw!' : `${result === 'w' ? 'White' : 'Black'} wins!`}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/components/RoomShell.tsx
+++ b/src/components/RoomShell.tsx
@@ -28,12 +28,12 @@ export default function RoomShell({ roomId, role }: { roomId: string; role: 'X'|
   useEffect(() => {
     ;(async () => {
       const { send, leave } = await joinRoom(roomId, (e: GameEvent) => {
-        if (e.type === 'state') {
+        if (e.type === 'state' && 'currentTurn' in e && (e.currentTurn === 'X' || e.currentTurn === 'O')) {
           setBoard(fromSnapshot(e.snapshot))
           setTurn(e.currentTurn)
           setResult(e.winner ?? null)
         }
-        if (e.type === 'move') {
+        if (e.type === 'move' && 'cell' in e) {
           setBoard((b) => {
             const nb = applyMove(b, { cell: e.cell, symbol: e.symbol })
             const w = winner(nb)

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -2,8 +2,22 @@ import { supabase } from './supabase'
 
 export type GameEvent =
   | { type: 'join'; userId: string | undefined }
-  | { type: 'move'; cell: number; symbol: 'X'|'O' }
-  | { type: 'state'; snapshot: string; currentTurn: 'X'|'O'; winner?: 'X'|'O'|'draw' }
+  // tic tac toe events
+  | { type: 'move'; cell: number; symbol: 'X' | 'O' }
+  | {
+      type: 'state'
+      snapshot: string
+      currentTurn: 'X' | 'O'
+      winner?: 'X' | 'O' | 'draw'
+    }
+  // chess events
+  | { type: 'move'; from: string; to: string; promotion?: string }
+  | {
+      type: 'state'
+      snapshot: string
+      currentTurn: 'w' | 'b'
+      winner?: 'w' | 'b' | 'draw'
+    }
 
 export const joinRoom = async (roomId: string, onEvent: (e: GameEvent)=>void) => {
   const client = supabase()

--- a/supabase.sql
+++ b/supabase.sql
@@ -51,9 +51,9 @@ create table if not exists public.matches (
   player_x uuid references public.profiles(id),
   player_o uuid references public.profiles(id),
   status match_status not null default 'waiting',
-  current_turn text check (current_turn in ('X','O')) default 'X',
-  winner text check (winner in ('X','O','draw')),
-  snapshot text check (length(snapshot) = 9) default '.........',
+  current_turn text default 'X',
+  winner text,
+  snapshot text default '.........',
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- Allow creating chess matches with initial board state and turn
- Add dedicated chess room component and route handling
- Generalize realtime events and database schema for chess

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899d159ecac8330a28ce531d9bc3b0d